### PR TITLE
Update mailboxer gem fixes

### DIFF
--- a/db/migrate/20210729105649_add_delivery_tracking_info_to_mailboxer_receipts.mailboxer_engine.rb
+++ b/db/migrate/20210729105649_add_delivery_tracking_info_to_mailboxer_receipts.mailboxer_engine.rb
@@ -1,0 +1,8 @@
+# This migration comes from mailboxer_engine (originally 20151103080417)
+class AddDeliveryTrackingInfoToMailboxerReceipts < ActiveRecord::Migration[4.2]
+  def change
+    add_column :mailboxer_receipts, :is_delivered, :boolean, default: false
+    add_column :mailboxer_receipts, :delivery_method, :string
+    add_column :mailboxer_receipts, :message_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_01_204556) do
+ActiveRecord::Schema.define(version: 2021_07_29_105649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -342,6 +342,9 @@ ActiveRecord::Schema.define(version: 2020_06_01_204556) do
     t.string "mailbox_type", limit: 25
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_delivered", default: false
+    t.string "delivery_method"
+    t.string "message_id"
     t.index ["notification_id"], name: "index_mailboxer_receipts_on_notification_id"
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
   end


### PR DESCRIPTION
Fixes #1732

Adds a missing migration of the Mailboxer gem that was making the email notification delivery throw a 500 error.
The migration file has been generated using the instructions at: mailboxer/mailboxer#391
`rails g mailboxer:install`

Changes proposed in this pull request:
Run rails g mailboxer:install to add the missing migration file


@samvera/hyku-code-reviewers